### PR TITLE
Adds support for uberstate splits. 

### DIFF
--- a/Logic/LogicManager.cs
+++ b/Logic/LogicManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using LiveSplit.Options;
 namespace LiveSplit.OriWotW {
     public class LogicManager {
         public bool ShouldSplit { get; private set; }
@@ -158,6 +159,9 @@ namespace LiveSplit.OriWotW {
                         Vector4 hitbox = new Vector4(split.Value);
                         CheckHitbox(hitbox);
                         break;
+                    case SplitType.UberState:
+                        CheckBoolUberState(split);
+                        break;
                     case SplitType.GameEnd:
                         CheckHitbox(new Vector4("-4628.05,-6756,10,10"));
                         break;
@@ -262,6 +266,20 @@ namespace LiveSplit.OriWotW {
                 case SplitSpiritTrial.WellspringComplete: CheckUberIntValue(UberStateDefaults.wellspringRace, 2); break;
                 case SplitSpiritTrial.WindsweptWastesActivate: CheckUberIntValue(UberStateDefaults.desertRace, 1); break;
                 case SplitSpiritTrial.WindsweptWastesComplete: CheckUberIntValue(UberStateDefaults.desertRace, 2); break;
+            }
+        }
+        private void CheckBoolUberState(Split split) {
+            try {
+                var parts = split.Value.Split('|');
+                if (int.TryParse(parts[0], out int groupId)) {
+                    if (int.TryParse(parts[1], out int id)) {
+                        CheckUberBoolValue(Memory.GetUberState(groupId, id));
+                    } 
+                    else Log.Error($"failed to parse {split.Value}");
+                } 
+                else Log.Error($"failed to parse {split.Value}");
+            } catch (Exception e) {
+                Log.Error($"Exception thrown parsing {split.Value}: {e}");
             }
         }
         private void CheckSeed(Split split) {

--- a/Logic/Split.cs
+++ b/Logic/Split.cs
@@ -40,7 +40,9 @@ namespace LiveSplit.OriWotW {
         [Description("Wisp")]
         Wisp,
         [Description("World Event")]
-        WorldEvent
+        WorldEvent,
+        [Description("Uber State")]
+        UberState
     }
     public class Split {
         public string Name { get; set; }

--- a/Memory/MemoryManager.cs
+++ b/Memory/MemoryManager.cs
@@ -256,6 +256,15 @@ namespace LiveSplit.OriWotW {
 
             return uberIDLookup;
         }
+
+        public UberState GetUberState(int groupId, int id) {
+            if (uberIDLookup == null) {
+                PopulateUberStates();
+            }
+            uberIDLookup.TryGetValue(((long)groupId << 32) | (long)id, out UberState value);
+            UpdateUberState(value);
+            return uberIDLookup[((long)groupId << 32) | (long)id];
+        }
         public void UpdateUberState(UberState uberState = null) {
             //UbserStateController.m_currentStateValueStore.m_groupMap
             IntPtr groups = UberStateController.Read<IntPtr>(Program, 0xb8, 0x40, 0x18);

--- a/UI/UserSplitSettings.cs
+++ b/UI/UserSplitSettings.cs
@@ -101,6 +101,13 @@ namespace LiveSplit.OriWotW {
                 txtValue.Width = 202;
                 txtValue.Visible = true;
                 cboValue.Visible = false;
+            } else if (nextControlType == SplitType.UberState) {
+                if (nextControlType != UserSplit.Type) {
+                    UserSplit.Value = "34543|11226";
+                }
+                txtValue.Width = 202;
+                txtValue.Visible = true;
+                cboValue.Visible = false;
             } else {
                 if (nextControlType != UserSplit.Type) {
                     switch (nextControlType) {


### PR DESCRIPTION
Split implementation parses as an uberID from a |-delimited int pair (usual  rando format).
Split check currently logs any errors from invalid input.
Default value is currently gameStateGroup gameFinished