### PR TITLE
Fix bug where the debug menu would not be properly re-enabled after a run

### DIFF
--- a/Logic/LogicManager.cs
+++ b/Logic/LogicManager.cs
@@ -5,7 +5,18 @@ namespace LiveSplit.OriWotW {
         public bool ShouldSplit { get; private set; }
         public bool ShouldReset { get; private set; }
         public int CurrentSplit { get; private set; }
-        public bool Running { get; private set; }
+
+        private bool _running;
+        public bool Running {
+            get => _running;
+            private set {
+                if (!_running && value) {
+                    hadDebug = Memory.DebugEnabled();
+                }
+                _running = value;
+            }
+        }
+
         public bool Paused { get; private set; }
         public float GameTime { get; private set; }
         public MemoryManager Memory { get; private set; }
@@ -64,7 +75,6 @@ namespace LiveSplit.OriWotW {
         public void Update(int currentSplit) {
             Memory.PatchNoPause(Settings.NoPause);
             if (Settings.DisableDebug && Running) {
-                hadDebug = Memory.DebugEnabled();
                 Memory.EnableDebug(false);
             }
 


### PR DESCRIPTION
The issue was that the `hadDebug` field was being set every update cycle, instead of only when the timer was started. Since there is no method that explicitly handles the logic for starting the timer, I decided to modify the `Running` property to set the value of `hadDebug` when it is set to `true` from `false`.

While not necessarily the most elegant solution it feels to be the safest solution given that there is no method that is only used to handle starting the timer.