### PR TITLE
Prologue testing

### DIFF
--- a/Memory/GameSettings.cs
+++ b/Memory/GameSettings.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.InteropServices;
+namespace LiveSplit.OriWotW {
+    public enum ControlScheme: byte {
+        Controller = 0,
+        KeyboardAndMouse = 1,
+        Keyboard = 2,
+        Switch = 3
+}
+
+    [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 1)]
+    public struct GameSettings {
+        [FieldOffset(0x0)]
+        public IntPtr Instance;
+        [FieldOffset(0x94)]
+        public ControlScheme m_currentControlSchemes;
+        [FieldOffset(0x88)]
+        public IntPtr m_unlockedCutscenes;
+        [FieldOffset(0xA8)]
+        public IntPtr m_hudEnabled;
+        [FieldOffset(0x58)]
+        public IntPtr m_language;
+    }
+}

--- a/Memory/MemoryManager.cs
+++ b/Memory/MemoryManager.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.IO;
+using System.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
+using LiveSplit.OriWotW;
 namespace LiveSplit.OriWotW {
     public partial class MemoryManager {
         private static ProgramPointer Characters = new ProgramPointer("GameAssembly.dll",
@@ -55,8 +58,11 @@ namespace LiveSplit.OriWotW {
             new FindPointerSignature(PointerVersion.All, AutoDeref.Single, "4885C00F8499000000488B80280100004885C00F849B00000048837820007675488B0D????????F6812701000002740E83B9D8000000007505E8", 0x23, 0x0));
         public static PointerVersion Version { get; set; } = PointerVersion.All;
         public Process Program { get; set; }
+        public Module64 GameAssembly { get; set; }
         public bool IsHooked { get; set; }
         public DateTime LastHooked { get; set; }
+        public Nullable<ControlScheme> LastControlScheme { get; set; }
+        public int ControllerCounter { get; set; } = 0;
         private bool? noPausePatched = null;
         private bool? debugEnabled = null;
         private FPSTimer fpsTimer = new FPSTimer(200, 15);
@@ -181,10 +187,27 @@ namespace LiveSplit.OriWotW {
             //TitleScreenManager.Instance.m_currentScreen
             return (Screen)TitleScreenManager.Read<int>(Program, 0xb8, 0x0, 0xb8);
         }
+        public Nullable<ControlScheme> GetControlScheme() {
+            GameSettings gameSettings = MemoryReader.Read<GameSettings>(Program, GameAssembly.BaseAddress, 0x04424A80, 0xB8, 0x0, 0xC0);
+
+            if (gameSettings.Instance != IntPtr.Zero)
+                return gameSettings.m_currentControlSchemes;
+
+            return null;
+        }
         public bool IsLoadingGame(GameState state) {
-            if (FrameCounter.GetPointer(Program) != IntPtr.Zero && fpsTimer.FPSShort == 0) {
+            Nullable<ControlScheme> CurrentControlScheme = GetControlScheme();
+
+            if (LastControlScheme != null && CurrentControlScheme != null && LastControlScheme != CurrentControlScheme) {
+                ControllerCounter = 0;
+            }
+            LastControlScheme = CurrentControlScheme;
+            ControllerCounter++;
+
+            if (FrameCounter.GetPointer(Program) != IntPtr.Zero && fpsTimer.FPSShort == 0 && ControllerCounter > 30) {
                 return true;
             }
+
             //int m_isLoadingGame = FindIl2CppOffset.GetOffset(Program, "__mainWisp.GameController.m_isLoadingGame");
             int m_isLoadingGame = Version == PointerVersion.All ? 0x103 : 0x10b;
             //GameController.FreezeFixedUpdate || GameController.Instance.m_isLoadingGame
@@ -192,8 +215,9 @@ namespace LiveSplit.OriWotW {
                 return true;
             }
             string scene = CurrentScene();
-            return (state == OriWotW.GameState.Game && (scene == "wotwTitleScreen" || scene == "kuFlyAway"))
-                || ((state == OriWotW.GameState.TitleScreen || state == OriWotW.GameState.StartScreen) && scene == "wotwTitleScreen");
+            return (state == OriWotW.GameState.TitleScreen || state == OriWotW.GameState.StartScreen) && scene == "wotwTitleScreen";
+            /*return (state == OriWotW.GameState.Game && (scene == "wotwTitleScreen" || scene == "kuFlyAway"))
+                || ((state == OriWotW.GameState.TitleScreen || state == OriWotW.GameState.StartScreen) && scene == "wotwTitleScreen");*/
         }
         private void PopulateUberStates() {
             uberIDLookup = new Dictionary<long, UberState>();
@@ -502,10 +526,10 @@ namespace LiveSplit.OriWotW {
                 if (Program != null && !Program.HasExited) {
                     MemoryReader.Update64Bit(Program);
                     FindIl2Cpp.InitializeIl2Cpp(Program);
-                    Module64 module = Program.Module64("GameAssembly.dll");
+                    GameAssembly = Program.Module64("GameAssembly.dll");
                     MemoryManager.Version = PointerVersion.All;
-                    if (module != null) {
-                        switch (module.MemorySize) {
+                    if (GameAssembly != null) {
+                        switch (GameAssembly.MemorySize) {
                             case 77447168: MemoryManager.Version = PointerVersion.V2; break;
                             case 77844480: MemoryManager.Version = PointerVersion.V3; break;
                         }

--- a/Memory/MemoryManager.cs
+++ b/Memory/MemoryManager.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.IO;
-using System.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
-using LiveSplit.OriWotW;
 namespace LiveSplit.OriWotW {
     public partial class MemoryManager {
         private static ProgramPointer Characters = new ProgramPointer("GameAssembly.dll",


### PR DESCRIPTION
Fixes the timer stopping in prologue and the timer micro stopping when you perform the janky slowdown, which is done by forcing the game to switch control scheme every frame which causes the FPS to drop too low which pauses the timer. I used 30 at line 207 in MemoryManager.cs because it was the lowest value where it didn't do micro pauses for me. I've done several pointer scans for the pointer and the amount of pointers hasn't changed the last 10 scans. Sickynar and KlebeZettel5 have been testing the dll doing runs with it and they haven't reported anything odd/weird happening. I couldn't find a single class that had an instance of the GameSettings class which is why I used a pointer.