### PR TITLE
Trials splitting and auto reset/stop and race timer as game time.

### DIFF
--- a/LiveSplit.OriWotW.csproj
+++ b/LiveSplit.OriWotW.csproj
@@ -75,15 +75,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="LiveSplit.Core">
-      <HintPath>..\..\LiveSplit\LiveSplit.Core.dll</HintPath>
+      <HintPath>C:\Users\Tekoppar\Desktop\Livesplit\LiveSplit.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="LiveSplit.Text">
-      <HintPath>..\..\LiveSplit\Components\LiveSplit.Text.dll</HintPath>
+      <HintPath>C:\Users\Tekoppar\Desktop\Livesplit\Components\LiveSplit.Text.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="LiveSplit.View">
-      <HintPath>..\..\LiveSplit\LiveSplit.View.dll</HintPath>
+      <HintPath>C:\Users\Tekoppar\Desktop\Livesplit\LiveSplit.View.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -92,7 +92,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="UpdateManager">
-      <HintPath>..\..\LiveSplit\UpdateManager.dll</HintPath>
+      <HintPath>C:\Users\Tekoppar\Desktop\Livesplit\UpdateManager.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -124,6 +124,7 @@
     <Compile Include="Memory\FPSTimer.cs" />
     <Compile Include="Memory\GameSettings.cs" />
     <Compile Include="Memory\GameState.cs" />
+    <Compile Include="Memory\RaceSystem.cs" />
     <Compile Include="Memory\Screen.cs" />
     <Compile Include="Memory\Shard.cs" />
     <Compile Include="Memory\Stats.cs" />
@@ -202,8 +203,8 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy $(TargetPath) $(ProjectDir)Components\$(TargetFileName)
-copy $(TargetPath) D:\Extra\LiveSplit\Components\$(TargetFileName)</PostBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Logic/Split.cs
+++ b/Logic/Split.cs
@@ -42,7 +42,9 @@ namespace LiveSplit.OriWotW {
         [Description("World Event")]
         WorldEvent,
         [Description("Uber State")]
-        UberState
+        UberState,
+        [Description("Race State")]
+        RaceState
     }
     public class Split {
         public string Name { get; set; }

--- a/Logic/SplitSpiritTrial.cs
+++ b/Logic/SplitSpiritTrial.cs
@@ -34,4 +34,15 @@ namespace LiveSplit.OriWotW {
         [Description("Windswept Wastes (Complete)")]
         WindsweptWastesComplete
     }
+
+    public enum SplitRace {
+        [Description("Race Has Started")]
+        RaceHasStarted,
+        [Description("Race Has Finished")]
+        RaceHasFinished,
+        [Description("Race Has Started Auto Reset")]
+        RaceHasStartedAutoReset,
+        [Description("Race Has Finished Auto Stop")]
+        RaceHasFinishedAutoStop
+    }
 }

--- a/Logic/SplitterSettings.cs
+++ b/Logic/SplitterSettings.cs
@@ -4,6 +4,7 @@ namespace LiveSplit.OriWotW {
         public BindingList<Split> Autosplits = new BindingList<Split>();
         public bool NoPause;
         public bool DisableDebug;
+        public bool UseRaceTime;
 
         public SplitterSettings() {
             Autosplits.AllowNew = true;
@@ -11,6 +12,7 @@ namespace LiveSplit.OriWotW {
             Autosplits.AllowEdit = true;
             NoPause = false;
             DisableDebug = false;
+            UseRaceTime = false;
         }
     }
 }

--- a/Memory/MemoryManager.cs
+++ b/Memory/MemoryManager.cs
@@ -114,9 +114,6 @@ namespace LiveSplit.OriWotW {
         public Module64 GameAssembly;
         public bool IsHooked { get; set; }
         public DateTime LastHooked { get; set; }
-        public int LastMStatePtrCheck = 0;
-        public IntPtr MState;
-        public IntPtr MState2;
         public ControlScheme LastControlScheme { get; set; }
         public int ControllerCounter { get; set; } = 0;
         private bool? noPausePatched = null;

--- a/Memory/MemoryManager.cs
+++ b/Memory/MemoryManager.cs
@@ -797,10 +797,10 @@ namespace LiveSplit.OriWotW {
                 if (Program != null && !Program.HasExited) {
                     MemoryReader.Update64Bit(Program);
                     FindIl2Cpp.InitializeIl2Cpp(Program);
-                    GameAssembly = Program.Module64("GameAssembly.dll");
+                    Module64 gameAssembly = Program.Module64("GameAssembly.dll");
                     MemoryManager.Version = PointerVersion.All;
-                    if (GameAssembly != null) {
-                        switch (GameAssembly.MemorySize) {
+                    if (gameAssembly != null) {
+                        switch (gameAssembly.MemorySize) {
                             case 77447168: MemoryManager.Version = PointerVersion.P1; break;
                             case 77844480: MemoryManager.Version = PointerVersion.P2; break;
                             case 81121280: MemoryManager.Version = PointerVersion.P3; break;

--- a/Memory/MemoryManager.cs
+++ b/Memory/MemoryManager.cs
@@ -601,6 +601,7 @@ namespace LiveSplit.OriWotW {
             RaceSystemPtr raceSystemPtr = new RaceSystemPtr();
 
             switch (Version) {
+                case PointerVersion.P1:
                 case PointerVersion.P2: {
                         RaceSystemPtrV2 raceSystemPtrV2 = MemoryReader.Read<RaceSystemPtrV2>(Program, raceSystem);
                         raceSystemPtr.Context = raceSystemPtrV2.Context;
@@ -629,6 +630,7 @@ namespace LiveSplit.OriWotW {
                 IntPtr ptr1 = MemoryReader.Read<IntPtr>(Program, raceSystem.m_states, 0x10);
                 byte[] data = Program.Read(ptr1 + 0x20, count * 0x8);
                 switch (Version) {
+                    case PointerVersion.P1:
                     case PointerVersion.P2: {
                             RaceCountdownStatePtrV2 statePtrV2 = Program.Read<RaceCountdownStatePtrV2>((IntPtr)BitConverter.ToUInt64(data, 6 * 0x8));
                             raceCountdownStatePtr.CurrentTime = statePtrV2.CurrentTime;
@@ -654,6 +656,7 @@ namespace LiveSplit.OriWotW {
             m_timer timer = new m_timer();
 
             switch (Version) {
+                case PointerVersion.P1:
                 case PointerVersion.P2: {
                         m_timerV2 m_timerv2 = MemoryReader.Read<m_timerV2>(Program, raceSystem.m_timer);
                         timer.BestTime = m_timerv2.BestTime;
@@ -687,6 +690,7 @@ namespace LiveSplit.OriWotW {
             RaceSystemPtr raceSystem = GetRaceSystem();
 
             switch (Version) {
+                case PointerVersion.P1:
                 case PointerVersion.P2:
                     return MemoryReader.Read<float>(Program, raceSystem.m_timer, 0x18);
 
@@ -701,6 +705,7 @@ namespace LiveSplit.OriWotW {
             RaceStateMachineContext raceState = new RaceStateMachineContext();
 
             switch (Version) {
+                case PointerVersion.P1:
                 case PointerVersion.P2: {
                         RaceStateMachineContextV2 raceStateMachineContextV2 = MemoryReader.Read<RaceStateMachineContextV2>(Program, raceSystem.Context);
                         raceState.Configuration = raceStateMachineContextV2.Configuration;
@@ -734,6 +739,7 @@ namespace LiveSplit.OriWotW {
             RaceHandlerPtr handler = new RaceHandlerPtr();
 
             switch (Version) {
+                case PointerVersion.P1:
                 case PointerVersion.P2: {
                         RaceHandlerV2 raceHandler = MemoryReader.Read<RaceHandlerV2>(Program, context.Configuration, 0x20, 0x0);
                         RaceDataV2 raceData = MemoryReader.Read<RaceDataV2>(Program, raceHandler.Data);
@@ -767,6 +773,7 @@ namespace LiveSplit.OriWotW {
             RaceSystemPtr raceSystem = GetRaceSystem();
 
             switch (Version) {
+                case PointerVersion.P1:
                 case PointerVersion.P2:
                     return MemoryReader.Read<bool>(Program, raceSystem.m_timer, 0x4c);
 

--- a/Memory/RaceSystem.cs
+++ b/Memory/RaceSystem.cs
@@ -1,0 +1,344 @@
+﻿using System;
+using System.Runtime.InteropServices;
+namespace LiveSplit.OriWotW {
+    public enum RaceStopReason {
+        None = 0, // 0x0
+        Finished = 1, // 0x0
+        Timeout = 2, // 0x0
+        Death = 3, // 0x0
+        SpectatingFinished = 4, // 0x0
+        TechnicalFailure = 5, // 0x0
+        UserAction = 6, // 0x0
+    }
+    public struct RaceSystemPtr {
+        public IntPtr m_timer;
+        public IntPtr Context;
+        public IntPtr m_states;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceSystemPtrV2 {
+        [FieldOffset(40)]
+        public IntPtr m_timer;
+        [FieldOffset(320)]
+        public IntPtr Context;
+        [FieldOffset(336)]
+        public IntPtr m_states;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceSystemPtrV3V4 {
+        [FieldOffset(0x40)]
+        public IntPtr m_timer;
+        [FieldOffset(0x168)]
+        public IntPtr Context;
+        [FieldOffset(0x178)]
+        public IntPtr m_states;
+    }
+
+    public struct m_timer {
+        public float ElapsedTime;
+        public float PersonalBestTime;
+        public float BestTime;
+        public float TimeLimit;
+        public float TimeToBeat;
+        public float PreviousElapsedTime;
+        public float m_adjustedElapsedTime;
+        public bool m_startedRace;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct m_timerV2 {
+        [FieldOffset(24)]
+        public float ElapsedTime;
+        [FieldOffset(28)]
+        public float PersonalBestTime;
+        [FieldOffset(32)]
+        public float BestTime;
+        [FieldOffset(36)]
+        public float TimeLimit;
+        [FieldOffset(40)]
+        public float TimeToBeat;
+        [FieldOffset(44)]
+        public float PreviousElapsedTime;
+        [FieldOffset(76)]
+        public bool m_startedRace;
+        [FieldOffset(0x48)]
+        public float m_adjustedElapsedTime;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct m_timerV3V4 {
+        [FieldOffset(0x30)]
+        public float ElapsedTime;
+        [FieldOffset(0x34)]
+        public float PersonalBestTime;
+        [FieldOffset(0x3C)]
+        public float BestTime;
+        [FieldOffset(0x38)]
+        public float TimeLimit;
+        [FieldOffset(0x40)]
+        public float TimeToBeat;
+        [FieldOffset(0x44)]
+        public float PreviousElapsedTime;
+        [FieldOffset(0x64)]
+        public bool m_startedRace;
+        [FieldOffset(0x60)]
+        public float m_adjustedElapsedTime;
+    }
+
+    public struct RaceCountdownStatePtr {
+        public bool m_countdownFinished;
+        public IntPtr m_countdownTimeline;
+        public float CurrentTime;
+        public bool m_markerInitialized;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceCountdownStatePtrV2 {
+        [FieldOffset(24)]
+        public bool m_countdownFinished;
+        [FieldOffset(32)]
+        public IntPtr m_countdownTimeline;
+        [FieldOffset(184)]
+        public float CurrentTime;
+        [FieldOffset(256)]
+        public bool m_markerInitialized;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceCountdownStatePtrV3V4 {
+        [FieldOffset(0x18)]
+        public bool m_countdownFinished;
+        [FieldOffset(0x20)]
+        public IntPtr m_countdownTimeline;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct MoonTimelineV2 {
+        [FieldOffset(48)]
+        public bool PlayState;
+        [FieldOffset(180)]
+        public bool StartMode;
+        [FieldOffset(184)]
+        public float CurrentTime;
+        [FieldOffset(232)]
+        public bool m_isFinished;
+        [FieldOffset(256)]
+        public bool m_markerInitialized;
+        [FieldOffset(257)]
+        public bool m_contentEnd;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct MoonTimelineV3V4 {
+        [FieldOffset(0x08)]
+        public bool PlayState;
+        [FieldOffset(0xCC)]
+        public bool StartMode;
+        [FieldOffset(0xD0)]
+        public float CurrentTime;
+        [FieldOffset(0x100)]
+        public bool m_isFinished;
+        [FieldOffset(0x118)]
+        public bool m_markerInitialized;
+        [FieldOffset(0x119)]
+        public bool m_contentEnd;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceConfiguration {
+        [FieldOffset(24)]
+        public IntPtr Race;
+        [FieldOffset(32)]
+        public IntPtr Handler;
+    }
+
+    public struct RaceStateMachineContext {
+        public IntPtr Configuration;
+        public RaceStopReason StopReason;
+        public float DeltaTime;
+        public bool UserRequestedRetry;
+        public bool UserRequestedWatchReplay;
+        public bool UserRequestedLeaderboard;
+        public float LastRaceTime;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceStateMachineContextV2 {
+        [FieldOffset(0x18)]
+        public IntPtr Configuration;
+        [FieldOffset(60)]
+        public RaceStopReason StopReason;
+        [FieldOffset(64)]
+        public float DeltaTime;
+        [FieldOffset(208)]
+        public bool UserRequestedRetry;
+        [FieldOffset(209)]
+        public bool UserRequestedWatchReplay;
+        [FieldOffset(210)]
+        public bool UserRequestedLeaderboard;
+        [FieldOffset(0x104)]
+        public float LastRaceTime;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceStateMachineContextV3V4 {
+        [FieldOffset(0x18)]
+        public IntPtr Configuration;
+        [FieldOffset(0x3C)]
+        public RaceStopReason StopReason;
+        [FieldOffset(0x40)]
+        public float DeltaTime;
+        [FieldOffset(0xE0)]
+        public bool UserRequestedRetry;
+        [FieldOffset(0xE1)]
+        public bool UserRequestedWatchReplay;
+        [FieldOffset(0xE2)]
+        public bool UserRequestedLeaderboard;
+        [FieldOffset(0x114)]
+        public float LastRaceTime;
+    }
+
+    public struct RaceHandlerPtr {
+        public RaceData Data;
+        public bool m_initialized;
+        public bool m_inProgress;
+        public bool m_inStartProximity;
+        public bool m_inEndProximity;
+        public bool m_isSyncing;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceHandlerV2 {
+        [FieldOffset(0x18)]
+        public IntPtr Data;
+        [FieldOffset(0x20)]
+        public bool m_initialized;
+        [FieldOffset(0x21)]
+        public bool m_inProgress;
+        [FieldOffset(0x22)]
+        public bool m_inStartProximity;
+        [FieldOffset(0x23)]
+        public bool m_inEndProximity;
+        [FieldOffset(0x24)]
+        public bool m_isSyncing;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceHandlerV3V4 {
+        [FieldOffset(0x30)]
+        public IntPtr Data;
+        [FieldOffset(0x38)]
+        public bool m_initialized;
+        [FieldOffset(0x39)]
+        public bool m_inProgress;
+        [FieldOffset(0x3A)]
+        public bool m_inStartProximity;
+        [FieldOffset(0x3B)]
+        public bool m_inEndProximity;
+        [FieldOffset(0x3C)]
+        public bool m_isSyncing;
+    }
+
+    public struct RaceData {
+        public int m_raceState;
+        public bool RaceInProgressState;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceDataV2 {
+        [FieldOffset(0x18)]
+        public IntPtr m_raceState;
+        [FieldOffset(0x60)]
+        public IntPtr RaceInProgressState;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceDataV3V4 {
+        [FieldOffset(0x30)]
+        public IntPtr m_raceState;
+        [FieldOffset(0x80)]
+        public IntPtr RaceInProgressState;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct MoonRaceV2 {
+        [FieldOffset(104)]
+        public IntPtr m_startTransform;
+        [FieldOffset(120)]
+        public IntPtr m_endTransform;
+        [FieldOffset(176)]
+        public IntPtr CountdownTimeline;
+        [FieldOffset(232)]
+        public IntPtr StartZoneChecker;
+        [FieldOffset(240)]
+        public IntPtr EndZoneChecker;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct MoonRaceV3V4 {
+        [FieldOffset(0x88)]
+        public IntPtr m_startTransform;
+        [FieldOffset(0x98)]
+        public IntPtr m_endTransform;
+        [FieldOffset(0xD0)]
+        public IntPtr CountdownTimeline;
+        [FieldOffset(0x108)]
+        public IntPtr StartZoneChecker;
+        [FieldOffset(0x110)]
+        public IntPtr EndZoneChecker;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct RaceHandlerV2V3V4 {
+        [FieldOffset(48)]
+        public Vector2 m_oriStartRacePosition;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct ObjectInsideZoneCheckerV2 {
+        [FieldOffset(24)]
+        public Rect m_bounds;
+        [FieldOffset(40)]
+        public IntPtr ExternalTransform;
+        [FieldOffset(48)]
+        public Vector2 Size;
+        [FieldOffset(56)]
+        public Vector2 Anchor;
+        [FieldOffset(64)]
+        public float checkResultDelay;
+        [FieldOffset(68)]
+        public IntPtr EditorColor;
+        [FieldOffset(88)]
+        public bool OnlyTriggerIfGrounded;
+    }
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct ObjectInsideZoneCheckerV3V4 {
+        [FieldOffset(0x30)]
+        public Rect m_bounds;
+        [FieldOffset(0x40)]
+        public IntPtr ExternalTransform;
+        [FieldOffset(0x48)]
+        public Vector2 Size;
+        [FieldOffset(0x50)]
+        public Vector2 Anchor;
+        [FieldOffset(0x58)]
+        public float checkResultDelay;
+        [FieldOffset(0x5C)]
+        public IntPtr EditorColor;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 200, Pack = 1)]
+    public struct Rect {
+        [FieldOffset(0)]
+        public float m_XMin;
+        [FieldOffset(4)]
+        public float m_YMin;
+        [FieldOffset(8)]
+        public float m_Width;
+        [FieldOffset(12)]
+        public float m_Height;
+    }
+
+    public class RaceSystemV2 {
+        public m_timerV2 Timer;
+        public MoonTimelineV2 CountdownTimeline;
+    }
+    public class RaceSystemV3V4 {
+        public m_timerV3V4 Timer;
+        public MoonTimelineV3V4 CountdownTimeline;
+    }
+
+    public class RaceState {
+        public bool RaceHasStarted { get; set; } = false;
+        public RaceStopReason LastReason { get; set; } = RaceStopReason.None;
+    }
+}

--- a/UI/Component.cs
+++ b/UI/Component.cs
@@ -108,8 +108,26 @@ namespace LiveSplit.OriWotW {
             if (Model == null) { return; }
 
             Model.CurrentState.IsGameTimePaused = logic.Paused;
-            if (logic.GameTime >= 0) {
-                Model.CurrentState.SetGameTime(TimeSpan.FromSeconds(logic.GameTime));
+            if (logic.Memory.IsHooked == true) {
+                if (logic.ShouldResetRace() == true || logic.ShouldResetRaceOver() == true) {
+                    isAutosplitting = true;
+                    logic.RaceState.RaceHasStarted = false;
+                    Model.Reset();
+                }
+                if (logic.CurrentSplit < logic.Settings.Autosplits.Count && userSettings.Settings.UseRaceTime == true) {
+                    float elapsedTime = logic.Memory.GetRacetimerElapsedTime();
+                    if (elapsedTime > 0.0f)
+                        Model.CurrentState.SetGameTime(TimeSpan.FromSeconds(elapsedTime));
+                } else if (logic.CurrentSplit >= logic.Settings.Autosplits.Count && userSettings.Settings.UseRaceTime == true) {
+                    m_timer elapsedTime = logic.Memory.GetRaceTimer();
+                    RaceStateMachineContext context = logic.Memory.GetRaceStateContext();
+                    if (elapsedTime.ElapsedTime > 0.0f)
+                        Model.CurrentState.SetGameTime(TimeSpan.FromSeconds(elapsedTime.ElapsedTime));
+                    else if (elapsedTime.ElapsedTime == 0.0f)
+                        Model.CurrentState.SetGameTime(TimeSpan.FromSeconds(context.LastRaceTime));
+                } else if (logic.GameTime >= 0.0f) {
+                    Model.CurrentState.SetGameTime(TimeSpan.FromSeconds(logic.GameTime));
+                }
             }
 
             if (logic.ShouldReset) {

--- a/UI/UserSettings.Designer.cs
+++ b/UI/UserSettings.Designer.cs
@@ -31,6 +31,7 @@
             this.chkNoPause = new System.Windows.Forms.CheckBox();
             this.chkDebug = new System.Windows.Forms.CheckBox();
             this.tooltips = new System.Windows.Forms.ToolTip(this.components);
+            this.chkUseRaceTime = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // btnLog
@@ -54,9 +55,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.flowMain.AutoScroll = true;
             this.flowMain.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowMain.Location = new System.Drawing.Point(0, 33);
+            this.flowMain.Location = new System.Drawing.Point(0, 58);
             this.flowMain.Name = "flowMain";
-            this.flowMain.Size = new System.Drawing.Size(470, 300);
+            this.flowMain.Size = new System.Drawing.Size(470, 275);
             this.flowMain.TabIndex = 0;
             this.flowMain.WrapContents = false;
             this.flowMain.DragEnter += new System.Windows.Forms.DragEventHandler(this.flowMain_DragEnter);
@@ -109,10 +110,22 @@
         "ished");
             this.chkDebug.UseVisualStyleBackColor = true;
             // 
+            // chkUseRaceTime
+            // 
+            this.chkUseRaceTime.AutoSize = true;
+            this.chkUseRaceTime.Location = new System.Drawing.Point(3, 31);
+            this.chkUseRaceTime.Name = "chkUseRaceTime";
+            this.chkUseRaceTime.Size = new System.Drawing.Size(100, 17);
+            this.chkUseRaceTime.TabIndex = 7;
+            this.chkUseRaceTime.Text = "Use Race Time";
+            this.tooltips.SetToolTip(this.chkUseRaceTime, "Uses the in game race timers time for the game time.");
+            this.chkUseRaceTime.UseVisualStyleBackColor = true;
+            // 
             // UserSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.chkUseRaceTime);
             this.Controls.Add(this.chkDebug);
             this.Controls.Add(this.chkNoPause);
             this.Controls.Add(this.chkLog);
@@ -136,5 +149,6 @@
         private System.Windows.Forms.CheckBox chkNoPause;
         private System.Windows.Forms.CheckBox chkDebug;
         private System.Windows.Forms.ToolTip tooltips;
+        private System.Windows.Forms.CheckBox chkUseRaceTime;
     }
 }

--- a/UI/UserSettings.cs
+++ b/UI/UserSettings.cs
@@ -44,6 +44,9 @@ namespace LiveSplit.OriWotW {
             AddXmlItem<bool>(document, xmlSettings, "DisableDebug", chkDebug.Checked);
             Settings.DisableDebug = chkDebug.Checked;
 
+            AddXmlItem<bool>(document, xmlSettings, "UseRaceTime", chkUseRaceTime.Checked);
+            Settings.UseRaceTime = chkUseRaceTime.Checked;
+
             XmlElement xmlSplits = document.CreateElement("Splits");
             xmlSettings.AppendChild(xmlSplits);
 
@@ -70,6 +73,10 @@ namespace LiveSplit.OriWotW {
             bool disableDebug = GetXmlBoolItem(node, ".//DisableDebug", true);
             chkDebug.Checked = disableDebug;
             Settings.DisableDebug = disableDebug;
+
+            bool useRaceTime = GetXmlBoolItem(node, ".//UseRaceTime", false);
+            chkUseRaceTime.Checked = useRaceTime;
+            Settings.UseRaceTime = useRaceTime;
 
             XmlNodeList splitNodes = node.SelectNodes(".//Splits/Split");
             foreach (XmlNode splitNode in splitNodes) {

--- a/UI/UserSplitSettings.cs
+++ b/UI/UserSplitSettings.cs
@@ -66,6 +66,10 @@ namespace LiveSplit.OriWotW {
                         cboValue.DataSource = Utility.GetEnumList<SplitWorldEvent>();
                         cboValue.SelectedValue = Utility.GetEnumValue<SplitWorldEvent>(UserSplit.Value);
                         break;
+                    case SplitType.RaceState:
+                        cboValue.DataSource = Utility.GetEnumList<SplitRace>();
+                        cboValue.SelectedValue = Utility.GetEnumValue<SplitRace>(UserSplit.Value);
+                        break;
                     default:
                         txtValue.Text = UserSplit.Value;
                         break;
@@ -122,6 +126,7 @@ namespace LiveSplit.OriWotW {
                         case SplitType.SpiritTrial: DefaultValue = SplitSpiritTrial.KwoloksHollowActivate; break;
                         case SplitType.Wisp: DefaultValue = SplitWisp.VoiceOfTheForest; break;
                         case SplitType.WorldEvent: DefaultValue = SplitWorldEvent.WaterPurified; break;
+                        case SplitType.RaceState: DefaultValue = SplitRace.RaceHasStarted; break;
                     }
                     UserSplit.Value = DefaultValue.ToString();
                 }


### PR DESCRIPTION
og1764 asked if I could add in functionality to auto reset the timer for spirit trials, so I've added 4 new splits 2 normal split ones that splits on trial start (that is when the timer starts) and one when you finish a trial, as well as 2 of the same splits but the start trial split timer resets the splits and the finished one resets the splits too but only when you're no longer racing. Both auto split types only works when they're the first and respective last ones, I also added in an option to use the race trial time for the LiveSplit game time. I've tested it on 1.2, 1.3, 1.3.1 and I've had og1764 also test it for some time.