### PR TITLE
Added pause fix for the first qtms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /LiveSplit.OriWotW.csproj.user
 /Components/OriWotW Manager.exe
 /Components/OriWotW Console.exe
+LiveSplit.OriWotW.csproj

--- a/Memory/Fader.cs
+++ b/Memory/Fader.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LiveSplit.OriWotW {
+    public enum FadeState {
+        Null = -1,
+        FadeToBlack = 0,
+        FadeStay = 1,
+        FadeFromBlack = 2,
+        Invisible = 3,
+        Timeline = 4,
+        EditorDebug = 5,
+        TimelineFinished = 6
+    };
+    public enum StartPauseState : int {
+        Null = -1,
+        StartedValueFalse = 0,
+        InGameUberValueTrue = 1,
+        QTMValueFalse = 2,
+        ReInGameUberValueTrue = 3,
+    };
+    public class Fader {
+        private FadeState CurrentState = FadeState.Null;
+        private float LastFadeTimer = -1.0f;
+        private bool FaderPaused = false;
+        private bool FadeStateChanged = false;
+        private int LastFrame = -1;
+        private StartPauseState startQTMState = StartPauseState.Null;
+        private bool startQTMStateShouldPause = true;
+        private bool lastRunning = false;
+
+        public bool IsPaused() { return FaderPaused; }
+        public void UpdateLastFader(float fadeTimer, int frameCount) {
+            LastFadeTimer = fadeTimer;
+            LastFrame = frameCount;
+
+            if (FadeStateChanged == true) {
+                FadeStateChanged = false;
+                //FaderPaused = false;
+            }
+        }
+        public void UpdateFadeState(FadeState fadeState) {
+            if (fadeState != CurrentState)
+                FadeStateChanged = true;
+
+            switch (fadeState) {
+                case FadeState.FadeFromBlack: CurrentState = FadeState.Null; LastFadeTimer = -1.0f; break;
+                case FadeState.FadeToBlack: CurrentState = FadeState.Null; LastFadeTimer = -1.0f; break;
+                case FadeState.FadeStay: CurrentState = fadeState; break;
+                case FadeState.Invisible: CurrentState = FadeState.Null; LastFadeTimer = -1.0f; break;
+                case FadeState.Timeline: CurrentState = FadeState.Null; LastFadeTimer = -1.0f;  break;
+                case FadeState.TimelineFinished: CurrentState = FadeState.Null; LastFadeTimer = -1.0f; break;
+            }
+        }
+
+        public void CheckStartQTM(string uberValue, GameState state, bool running) {
+            if (lastRunning == false && running == true && state != GameState.TitleScreen) {
+                startQTMStateShouldPause = false;
+                return;
+            }
+
+            switch (startQTMState) {
+                case StartPauseState.Null:
+                    if (state == OriWotW.GameState.TitleScreen && uberValue.Equals("False")) {
+                        startQTMState = StartPauseState.StartedValueFalse;
+                        startQTMStateShouldPause = true;
+                    }
+                    break;
+                case StartPauseState.StartedValueFalse:
+                    if (state == OriWotW.GameState.Game && uberValue.Equals("True")) {
+                        startQTMState = StartPauseState.InGameUberValueTrue;
+                        startQTMStateShouldPause = true;
+                    }
+                    break;
+                case StartPauseState.InGameUberValueTrue:
+                    if (state == OriWotW.GameState.StartScreen && startQTMState == StartPauseState.InGameUberValueTrue && uberValue.Equals("False")) {
+                        startQTMState = StartPauseState.QTMValueFalse;
+                        startQTMStateShouldPause = true;
+                    }
+                    break;
+                case StartPauseState.QTMValueFalse:
+                    if (state == OriWotW.GameState.Game && startQTMState == StartPauseState.QTMValueFalse && uberValue.Equals("True")) {
+                        startQTMState = StartPauseState.ReInGameUberValueTrue;
+                        startQTMStateShouldPause = false;
+                    }
+                    break;
+                case StartPauseState.ReInGameUberValueTrue:
+                    startQTMStateShouldPause = false;
+                    break;
+            }
+
+            lastRunning = running;
+        }
+
+        public void ResetStartQTM() {
+            startQTMState = StartPauseState.Null;
+            startQTMStateShouldPause = true;
+            lastRunning = false;
+        }
+
+        public void ShouldPause(float fadeTimer, int currentFrame) {
+            if (currentFrame != LastFrame) {
+                FaderPaused = false;
+
+                if (fadeTimer != LastFadeTimer && CurrentState != FadeState.Null)
+                    FaderPaused = true;
+            }
+
+            if (startQTMStateShouldPause == false) {
+                FaderPaused = false;
+                return;
+            }
+
+            FaderPaused = CurrentState != FadeState.Null ? FaderPaused : false;
+        }
+
+        public FadeState GetFadeState() {
+            return this.CurrentState;
+        }
+    }
+}

--- a/Memory/MemoryManager.cs
+++ b/Memory/MemoryManager.cs
@@ -111,6 +111,7 @@ namespace LiveSplit.OriWotW {
             new FindPointerSignature(PointerVersion.All, AutoDeref.Single, "448975E848C745EC??000000C645F400488D4DC8E8????????488905????????4885C00F84????????FFD0C64718014889471033C9E8????????4533C08BD0488BCFE8", 0x4a, 0x0));
         public static PointerVersion Version { get; set; } = PointerVersion.All;
         public Process Program { get; set; }
+        public Module64 GameAssembly { get; set; }
         public bool IsHooked { get; set; }
         public DateTime LastHooked { get; set; }
         public ControlScheme LastControlScheme { get; set; }
@@ -118,6 +119,7 @@ namespace LiveSplit.OriWotW {
         private bool? noPausePatched = null;
         private bool? debugEnabled = null;
         private FPSTimer fpsTimer = new FPSTimer(200, 15);
+        public Fader CurrentFader = new Fader();
         private PointerCache playerUberStateGroup = new PointerCache();
         private static Dictionary<long, UberState> uberIDLookup = null;
 
@@ -328,6 +330,35 @@ namespace LiveSplit.OriWotW {
             int m_currentControlSchemes = Version <= PointerVersion.P2 ? 0x94 : 0xd0;
             return GameSettings.Read<ControlScheme>(Program, 0xb8, 0x0, m_currentControlSchemes);
         }
+        public bool FaderPause() {
+            int currentFrameCount = FrameCount();
+            float fadeTimer = -1.0f;
+            FadeState fadeState = FadeState.Null;
+
+            //UI -> UI.static -> UI.Fader -> FaderB.m_stateCurrentTime
+            //UI -> UI.static -> UI.Fader -> FaderB.m_currentTimelineFaderType
+            switch (Version) {
+                case PointerVersion.P1:
+                    fadeTimer = MemoryReader.Read<float>(Program, GameAssembly.BaseAddress, 0x043E6650, 0xb8, 0x10, 0x50);
+                    fadeState = (FadeState)MemoryReader.Read<int>(Program, GameAssembly.BaseAddress, 0x043E6650, 0xb8, 0x10, 0x68);
+                    break;
+                case PointerVersion.P2:
+                    fadeTimer = MemoryReader.Read<float>(Program, GameAssembly.BaseAddress, 0x04464828, 0xb8, 0x10, 0x50);
+                    fadeState = (FadeState)MemoryReader.Read<int>(Program, GameAssembly.BaseAddress, 0x04464828, 0xb8, 0x10, 0x68);
+                    break;
+
+                case PointerVersion.P3:
+                case PointerVersion.P4:
+                    fadeTimer = MemoryReader.Read<float>(Program, GameAssembly.BaseAddress, 0x04783338, 0xb8, 0x10, 0x78);
+                    fadeState = (FadeState)MemoryReader.Read<int>(Program, GameAssembly.BaseAddress, 0x04783338, 0xb8, 0x10, 0x94);
+                    break;
+            }
+
+            CurrentFader.ShouldPause(fadeTimer, currentFrameCount);
+            CurrentFader.UpdateFadeState(fadeState);
+
+            return CurrentFader.IsPaused();
+        }
         public bool IsLoadingGame(GameState state) {
             ControlScheme currentControlScheme = GetControlScheme();
             if (LastControlScheme != currentControlScheme) {
@@ -346,6 +377,8 @@ namespace LiveSplit.OriWotW {
             if (GameController.Read<bool>(Program, 0xb8, 0xa) || GameController.Read<bool>(Program, 0xb8, 0x0, m_isLoadingGame)) {
                 return true;
             }
+            if (FaderPause())
+                return true;
             return (state == OriWotW.GameState.TitleScreen || state == OriWotW.GameState.StartScreen) && CurrentScene() == "wotwTitleScreen";
         }
         private void PopulateUberStates() {
@@ -700,6 +733,7 @@ namespace LiveSplit.OriWotW {
                     MemoryReader.Update64Bit(Program);
                     FindIl2Cpp.InitializeIl2Cpp(Program);
                     Module64 gameAssembly = Program.Module64("GameAssembly.dll");
+                    GameAssembly = Program.Module64("GameAssembly.dll");
                     MemoryManager.Version = PointerVersion.All;
                     if (gameAssembly != null) {
                         switch (gameAssembly.MemorySize) {


### PR DESCRIPTION
Added a pause fix from starting a new file to qtming and going back in to skip the intro storm cinematic. The reason being that the first qtm is heavily hardware dependent and you can loose/gain seconds here, this should equalize it a lot more. We've been discussing this for a long time in the meta-discussion - timing discussions thread. Snowstorm requested that the initial qtm was fixed due too being heavily hardware dependent, we brought this to meta-discussion ( https://discord.com/channels/116250700685508615/690018511778480150/921597980920926208 ) to see if people were against this change and so far nothing major has been brought up.

Hopefully the logic is sound in the class method Fader.CheckStartQTM, hopefully I haven't missed any cases.